### PR TITLE
Living large update

### DIFF
--- a/crates/formality-check/src/mini_rust_check.rs
+++ b/crates/formality-check/src/mini_rust_check.rs
@@ -4,7 +4,7 @@ use std::iter::zip;
 use formality_core::{judgment_fn, Downcast, Fallible, Map, Upcast};
 use formality_prove::{prove_normalize, AdtDeclBoundData, AdtDeclVariant, Constraints, Decls, Env};
 use formality_rust::grammar::minirust::ArgumentExpression::{ByValue, InPlace};
-use formality_rust::grammar::minirust::ValueExpression::{Constant, Fn, Load, Struct};
+use formality_rust::grammar::minirust::ValueExpression::{Constant, Fn, Load, Ref, Struct};
 use formality_rust::grammar::minirust::{
     self, ArgumentExpression, BasicBlock, BbId, LocalId, PlaceExpression, ValueExpression,
 };
@@ -124,7 +124,7 @@ impl TypeckEnv<'_> {
         match statement {
             minirust::Statement::Assign(place_expression, value_expression) => {
                 // Check if the place expression is well-formed.
-                let place_ty = self.check_place(place_expression)?;
+                let place_ty = self.check_place(fn_assumptions, place_expression)?;
 
                 // Check if the value expression is well-formed.
                 let value_ty = self.check_value(fn_assumptions, value_expression)?;
@@ -139,7 +139,7 @@ impl TypeckEnv<'_> {
             }
             minirust::Statement::PlaceMention(place_expression) => {
                 // Check if the place expression is well-formed.
-                self.check_place(place_expression)?;
+                self.check_place(fn_assumptions, place_expression)?;
                 // FIXME: check that access the place is allowed per borrowck rules
             }
             minirust::Statement::StorageLive(local_id) => {
@@ -209,7 +209,7 @@ impl TypeckEnv<'_> {
                 }
 
                 // Check whether ret place is well-formed.
-                let actual_return_ty = self.check_place(ret)?;
+                let actual_return_ty = self.check_place(fn_assumptions, ret)?;
 
                 // Check if the fn's declared return type is a subtype of the type of the local variable `ret`
                 self.prove_goal(
@@ -251,7 +251,7 @@ impl TypeckEnv<'_> {
     }
 
     // Check if the place expression is well-formed, and return the type of the place expression.
-    fn check_place(&mut self, place: &PlaceExpression) -> Fallible<Ty> {
+    fn check_place(&mut self, fn_assumptions: &Wcs, place: &PlaceExpression) -> Fallible<Ty> {
         let place_ty;
         match place {
             Local(local_id) => {
@@ -265,7 +265,9 @@ impl TypeckEnv<'_> {
                 place_ty = ty;
             }
             Field(field_projection) => {
-                let ty = self.check_place(&field_projection.root).unwrap();
+                let ty = self
+                    .check_place(fn_assumptions, &field_projection.root)
+                    .unwrap();
 
                 // FIXME(tiif): We eventually want to do normalization here, so check_place should be
                 // a judgment fn.
@@ -293,6 +295,12 @@ impl TypeckEnv<'_> {
 
                 place_ty = fields[field_projection.index].ty.clone();
             }
+            Deref(value_expr) => {
+                // FIXME(tiif): If ValueExpression::Ref return a type with lifetime,
+                // we should remove the lifetime from the type here?
+                self.check_value(fn_assumptions, value_expr)?;
+                todo!()
+            }
         }
         Ok(place_ty.clone())
     }
@@ -313,7 +321,7 @@ impl TypeckEnv<'_> {
         let value_ty;
         match value {
             Load(place_expression) => {
-                value_ty = self.check_place(place_expression)?;
+                value_ty = self.check_place(fn_assumptions, place_expression)?;
                 Ok(value_ty)
             }
             Fn(fn_id) => {
@@ -408,6 +416,11 @@ impl TypeckEnv<'_> {
 
                 Ok(ty.clone())
             }
+            Ref(place_expr) => {
+                self.check_place(fn_assumptions, place_expr)?;
+                // FIXME(tiif): We need to assign a lifetime here?
+                todo!()
+            }
         }
     }
 
@@ -422,7 +435,7 @@ impl TypeckEnv<'_> {
                 ty = self.check_value(fn_assumptions, val_expr)?;
             }
             InPlace(place_expr) => {
-                ty = self.check_place(place_expr)?;
+                ty = self.check_place(fn_assumptions, place_expr)?;
             }
         }
         Ok(ty)

--- a/crates/formality-check/src/mini_rust_check.rs
+++ b/crates/formality-check/src/mini_rust_check.rs
@@ -54,6 +54,7 @@ impl Check<'_> {
         };
 
         // Check if the actual return type is the subtype of the declared return type.
+        // FIXME(tiif): should this be subtype? I think v0's type should always equivalent to the return type?
         self.prove_goal(&env, fn_assumptions, Relation::sub(body_ret_ty, &output_ty))?;
 
         // ----------------------------------------------------------------------
@@ -512,6 +513,11 @@ impl TypeckEnv<'_> {
     /// Prove the goal with the function `judgment_fn`,
     /// adding any pending outlive constraints that are required
     /// for the goal to be true into `self.pending_outlives`.
+    ///
+    /// One of the difference between this prove_judgment and the one in impl Check is
+    /// that this version can accept existential variable, which is needed for handling lifetime.
+    /// In the compiler, we insert existential variables for all
+    /// lifetimes that appear in the MIR body, and I expect we will do the same here.
     fn prove_judgment<G>(
         &mut self,
         location: Location,
@@ -524,11 +530,6 @@ impl TypeckEnv<'_> {
     {
         let assumptions: Wcs = assumptions.to_wcs();
 
-        // TODO: This assertion states that there are no existential variables
-        // (i.e., no type/lifetime inference is required). This is not going to remain
-        // true much longer. In the compiler, we insert existential variables for all
-        // lifetimes that appear in the MIR body, and I expect we will do the same here.
-        assert!(self.env.only_universal_variables());
         assert!(self.env.encloses((&assumptions, &goal)));
 
         // Prove the goal using the given judgment + assumptions.

--- a/crates/formality-rust/src/grammar/minirust.rs
+++ b/crates/formality-rust/src/grammar/minirust.rs
@@ -92,6 +92,8 @@ id!(FieldId);
 pub struct Body {
     pub args: Vec<LocalId>,
     pub ret: LocalId,
+    // params contain function parameters and return local
+    // as their types does not contain region inference variable.
     pub params: Vec<LocalDecl>,
     pub binder: Binder<BodyBound>,
 }
@@ -101,6 +103,7 @@ pub struct Body {
     $*blocks
 })]
 pub struct BodyBound {
+    // locals contain every locals other than function parameters and return local.
     pub locals: Vec<LocalDecl>,
     pub blocks: Vec<BasicBlock>,
 }

--- a/crates/formality-rust/src/grammar/minirust.rs
+++ b/crates/formality-rust/src/grammar/minirust.rs
@@ -209,9 +209,12 @@ pub enum ValueExpression {
     // GetDiscriminant
     #[grammar(load($v0))]
     Load(PlaceExpression),
-    // AddrOf
-    // UnOp
-    // BinOp
+    // Similar to AddrOf in MiniRust, but we don't deal with other
+    // pointer type such as raw pointer and box yet.
+    #[grammar(&($v0))]
+    Ref(PlaceExpression), // AddrOf
+                          // UnOp
+                          // BinOp
 }
 
 #[term]
@@ -268,7 +271,8 @@ impl ConstTypePair {
 pub enum PlaceExpression {
     #[grammar(local($v0))]
     Local(LocalId),
-    // Deref(Arc<ValueExpression>),
+    #[grammar(*($v0))] // TODO: change syntax?
+    Deref(Arc<ValueExpression>),
     // Project to a field.
     #[grammar($v0)]
     Field(FieldProjection),

--- a/src/test/functions.rs
+++ b/src/test/functions.rs
@@ -30,7 +30,7 @@ fn ok() {
 
 #[test]
 fn lifetime() {
-    crate::assert_err!(
+    crate::assert_ok!(
         // Test lifetimes on function
         [
             crate Foo {
@@ -38,16 +38,6 @@ fn lifetime() {
                 fn one_lt_arg<lt a, ty T>(&a T) -> () { trusted }
             }
         ]
-
-        [ /* TODO */ ]
-
-        expect_test::expect![[r#"
-            judgment `prove { goal: {@ wf(&!lt_0 !ty_1)}, assumptions: {}, env: Env { variables: [!lt_0, !ty_1], bias: Soundness, pending: [] }, decls: decls(222, [], [], [], [], [], [], {}, {}) }` failed at the following rule(s):
-              failed at (src/file.rs:LL:CC) because
-                judgment `prove_wc_list { goals: {@ wf(&!lt_0 !ty_1)}, assumptions: {}, env: Env { variables: [!lt_0, !ty_1], bias: Soundness, pending: [] } }` failed at the following rule(s):
-                  the rule "some" failed at step #0 (src/file.rs:LL:CC) because
-                    judgment `prove_wc { goal: @ wf(&!lt_0 !ty_1), assumptions: {}, env: Env { variables: [!lt_0, !ty_1], bias: Soundness, pending: [] } }` failed at the following rule(s):
-                      the rule "parameter well formed" failed at step #0 (src/file.rs:LL:CC) because
-                        judgment had no applicable rules: `prove_wf { goal: &!lt_0 !ty_1, assumptions: {}, env: Env { variables: [!lt_0, !ty_1], bias: Soundness, pending: [] } }`"#]]
+        expect_test::expect![["()"]]
     )
 }

--- a/src/test/mir_fn_bodies.rs
+++ b/src/test/mir_fn_bodies.rs
@@ -1022,3 +1022,35 @@ fn test_ref_not_subtype() {
         expect_test::expect!["()"]
     )
 }
+
+/// Test ref and deref
+/// FIXME(tiif): This is not implemented yet
+#[test]
+#[ignore]
+fn test_ref_deref() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+
+                fn foo () -> u32 = minirust() -> v0 {
+                    let v0: u32;
+                    exists<lt a> {
+                        let v1: u32;
+                        let v2: &a u32;
+                        let v3: u32;
+
+                        bb0: {
+                            statements {
+                                local(v1) = constant(3: u32);
+                                local(v2) = &(local(v1));
+                                local(v3) = load(*(load(local(v2))));
+                            }
+                            return;
+                        }
+                    }
+                };
+            }
+        ]
+        expect_test::expect![["()"]]
+    )
+}

--- a/src/test/mir_fn_bodies.rs
+++ b/src/test/mir_fn_bodies.rs
@@ -950,17 +950,17 @@ fn test_non_adt_ty_for_struct() {
     )
 }
 
-/// Test a Rust function like
+/// Basic pass test for lifetime.
 ///
+/// The test is equivalent to:
 /// ```rust,ignore
-/// fn pick<'a>(x: &'a (u32, u32)) - &'a u32 {
-///     let tmp = x;
-///     tmp
+/// fn pick<'a>(v1: &'a u32) -> &'a u32 {
+///     let v2 = v1;
+///     v2
 /// }
 /// ```
 #[test]
 fn test_ref_identity() {
-    // Rust test
     crate::assert_ok!(
         [
             crate Foo {
@@ -982,6 +982,43 @@ fn test_ref_identity() {
                 };
             }
         ]
-        expect_test::expect!["The type used in ValueExpression::Struct must be adt"]
+        expect_test::expect!["()"]
+    )
+}
+
+/// FIXME(tiif): this should not pass, I think Relation::sub does not consider lifetime yet?
+/// Basic fail test for lifetime.
+///
+/// The test is equivalent to:
+/// ```rust,ignore
+/// fn pick<'a, 'b>(v1: &'a u32) -> &'b u32 {
+///     let v2 = v1;
+///     v2
+/// }
+/// ```
+#[test]
+fn test_ref_not_subtype() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                fn foo<lt a, lt b>(&a u32) -> &b u32 = minirust(v1) -> v0 {
+                    let v0: &b u32;
+                    let v1: &a u32;
+
+                    exists<lt r0> {
+                        let v2: &r0 u32;
+
+                        bb0: {
+                            statements {
+                                local(v2) = load(local(v1));
+                                local(v0) = load(local(v2));
+                            }
+                            return;
+                        }
+                    }
+                };
+            }
+        ]
+        expect_test::expect!["()"]
     )
 }


### PR DESCRIPTION
I removed the assert that used to prevent us from using existential variable in ``prove_judgment``, it works fine. 

Things to do this week:
1. ``test_ref_not_subtype`` passed although it shouldn't. I think this happen because ``Relation::Sub`` does not properly handle lifetime yet.
2. I added a test and grammar for ``Ref`` and ``Deref``, it'll be nice to complete the implementation for this as it will allow us to write more interesting tests.